### PR TITLE
Rename crate from letta-rs to letta

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -39,10 +39,16 @@
       "mcp__context7__get-library-docs",
       "Bash(-w \"\\nHTTP Status: %{http_code}\\n\")",
       "Bash(just pre-commit:*)",
-      "WebFetch(domain:raw.githubusercontent.com)"
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "mcp__language-server__diagnostics",
+      "mcp__language-server__hover",
+      "mcp__language-server__definition",
+      "mcp__language-server__rename_symbol"
     ],
     "deny": []
   },
-  "enabledMcpjsonServers": ["language-server"],
-  "enableAllProjectMcpServers": true
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "language-server"
+  ]
 }

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .claude/settings.local.json
 /.pre-commit-config.yaml
 .mcp.json
+CLAUDE.md.local
+mcp-wrapper.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is the development guide for contributing to letta-rs, a Rust client library for the Letta REST API. This document contains internal implementation details, coding standards, and development workflows. For user documentation, see README.md.
+This is the development guide for contributing to letta, a Rust client library for the Letta REST API. This document contains internal implementation details, coding standards, and development workflows. For user documentation, see README.md.
 
 ### Implementation Status
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ LETTA_API_KEY=your-key nix run .#test-all
 
 ### Test Environment Setup
 
-1. **Local Server Tests**: 
+1. **Local Server Tests**:
    - Copy `server.env.example` to `server.env`
    - The example file contains minimal config for embedded PostgreSQL
    - Optional: Add your own API keys for Azure, Composio, etc.
@@ -233,86 +233,12 @@ cargo test --doc         # Doc tests
 - **Local Testing**: Use local-server/ for development
 - **Type Discovery**: Use `curl -v` against local server to inspect responses
 
-## Potential Ergonomic Improvements
+## Remaining Tasks
 
-### 1. Add Default Implementations
-Many request types with all-optional fields should implement `Default`:
-- `UpdateMemoryBlockRequest` - Currently requires listing all fields as None
-- `ListBlocksParams`, `ListToolsParams`, `UpdateBlockRequest`, `UpdateSourceRequest`
-- `ImportAgentRequest`, `AgentsSearchRequest`
-- `ListFilesParams`, `ListPassagesParams`
-
-### 2. Builder Patterns
-While `CreateAgentRequest` has a builder, these complex types need them too:
-- `CreateMessagesRequest` - Often just needs messages field
-- `CreateBlockRequest`, `CreateSourceRequest`, `CreateToolRequest`
-- `ProviderCreate`, `CreateIdentityRequest`
-- `MessageCreate` - Has convenience methods but builder would help complex cases
-
-### 3. Smart Constructors
-Common patterns that appear in tests could use convenience constructors:
-```rust
-// Instead of 15 fields with mostly None:
-Block::new("human", "The human's name is Bob")
-    .with_limit(1000)
-    .with_description("Human information")
-
-// LLM config shortcuts:
-LLMConfig::openai("gpt-4")
-LLMConfig::anthropic("claude-3")
-LLMConfig::local("llama2").with_endpoint("http://localhost:8080")
-```
-
-### 4. Missing From/Into Implementations
-- `impl From<&str> for LettaId` (for convenience in tests)
-- `impl From<Vec<String>> for MessageCreateContent` (for multi-part messages)
-- `impl TryFrom<&str> for ProviderType` (with proper error handling)
-
-### 5. Pagination Trait
-All pagination params follow same pattern but lack consistency:
-```rust
-trait PaginationExt {
-    fn limit(self, limit: u32) -> Self;
-    fn after(self, cursor: impl Into<String>) -> Self;
-}
-```
-
-### 6. Memory Block Presets
-Common memory blocks appear in every agent:
-```rust
-Block::human("Bob")  // Creates human memory block
-Block::persona("A helpful assistant")  // Creates persona block
-```
-
-### 7. Tool Rule Builders
-Complex enums like `ToolRule` need builders:
-```rust
-ToolRule::conditional("my_tool")
-    .with_mapping("yes", "approve_tool")
-    .with_mapping("no", "deny_tool")
-```
-
-### 8. Response Format Shortcuts
-```rust
-ResponseFormat::json(schema)
-ResponseFormat::text()
-```
-
-### 9. Test Helpers
-Common test patterns could have helpers:
-```rust
-CreateToolRequest::test_echo_tool("my_tool")
-CreateAgentRequest::test_agent("TestBot")
-```
-
-### 10. Error Context Methods
-Operations could add context to errors:
-```rust
-client.sources()
-    .upload_file(source_id, path)
-    .await
-    .context_file(path)?  // Adds file path to error
-```
+1. **Rename crate to `letta`** - Update Cargo.toml and all references
+2. **Documentation pass** - Update examples to use new ergonomic features
+3. **Finish CLI implementation** - Currently only generates JSON, needs to make actual API calls
+4. **Implement upsert-from-function** - Port Python SDK's function-based agent creation feature
 
 ## Recent Implementation Notes
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,7 +930,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "letta"
-version = "0.1.0"
+version = "0.1.2"
 dependencies = [
  "bon",
  "bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -929,7 +929,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "letta-rs"
+name = "letta"
 version = "0.1.0"
 dependencies = [
  "bon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 # If you change the name here, you must also do it in flake.nix (and run `cargo generate-lockfile` afterwards)
 name = "letta"
 description = "A robust Rust client for the Letta REST API"
-version = "0.1.0"
+version = "0.1.2"
 license = "MIT"
 repository = "https://github.com/srid/letta-rs"
 keywords = ["letta", "ai", "agents", "api", "client"]
@@ -13,6 +13,9 @@ readme = "README.md"
 documentation = "https://docs.rs/letta"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[package.metadata]
+letta-server-version = "0.8.8"
 
 [dependencies]
 # HTTP client

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["letta", "ai", "agents", "api", "client"]
 categories = ["api-bindings", "web-programming::http-client"]
 readme = "README.md"
 documentation = "https://docs.rs/letta"
+# ...
+exclude = [".claude", "CLAUDE*", "*.md"]
+include = ["README.md"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Orual <orual@nonbinary.computer>"]
 edition = "2021"
 # If you change the name here, you must also do it in flake.nix (and run `cargo generate-lockfile` afterwards)
-name = "letta-rs"
+name = "letta"
 description = "A robust Rust client for the Letta REST API"
 version = "0.1.0"
 license = "MIT"
@@ -10,7 +10,7 @@ repository = "https://github.com/srid/letta-rs"
 keywords = ["letta", "ai", "agents", "api", "client"]
 categories = ["api-bindings", "web-programming::http-client"]
 readme = "README.md"
-documentation = "https://docs.rs/letta-rs"
+documentation = "https://docs.rs/letta"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# letta-rs
+# letta
 
 A Rust client library for the [Letta](https://letta.com) REST API, providing idiomatic Rust bindings for building stateful AI agents with persistent memory and context.
 
 Unlike the Letta-provided TypeScript and Python libraries, this was not generated from the OpenAPI spec, but implemented by hand (with substantial LLM assistance). As such it exposes things in slightly different, mildly opinionated ways, and includes a number of Rust-oriented affordances.
 
-[![Crates.io](https://img.shields.io/crates/v/letta.svg)](https://crates.io/crates/letta-rs)
-[![Documentation](https://docs.rs/letta/badge.svg)](https://docs.rs/letta-rs)
+[![Crates.io](https://img.shields.io/crates/v/letta.svg)](https://crates.io/crates/letta)
+[![Documentation](https://docs.rs/letta/badge.svg)](https://docs.rs/letta)
 [![License](https://img.shields.io/crates/l/letta.svg)](LICENSE)
 
 ## Features
@@ -248,8 +248,8 @@ match client.agents().get(&agent_id).await {
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/letta-rs
-cd letta-rs
+git clone https://github.com/yourusername/letta
+cd letta
 
 # Build the library
 cargo build

--- a/README.md
+++ b/README.md
@@ -22,9 +22,16 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-letta = "0.1.0"
+letta = "0.1.2"
 tokio = { version = "1", features = ["full"] }
 ```
+
+## Compatibility
+
+| letta client | letta server |
+|--------------|--------------|
+| 0.1.2        | 0.8.8        |
+| 0.1.0-0.1.1  | 0.8.x        |
 
 ## Quick Start
 

--- a/nix/modules/devshell.nix
+++ b/nix/modules/devshell.nix
@@ -2,7 +2,7 @@
 {
   perSystem = { config, self', pkgs, lib, ... }: {
     devShells.default = pkgs.mkShell {
-      name = "letta-rs-shell";
+      name = "letta-shell";
       inputsFrom = [
         self'.devShells.rust
         config.pre-commit.devShell # See ./nix/modules/pre-commit.nix

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -60,7 +60,7 @@
       '';
     in
     {
-      rust-project.crates."letta-rs".crane.args = {
+      rust-project.crates."letta".crane.args = {
         # Enable checks
         doCheck = true;
 
@@ -94,10 +94,10 @@
       };
 
       packages = {
-        default = self'.packages.letta-rs;
+        default = self'.packages.letta;
 
         # Package for running tests with local server
-        letta-rs-with-tests = self'.packages.letta-rs.overrideAttrs (oldAttrs: {
+        letta-with-tests = self'.packages.letta.overrideAttrs (oldAttrs: {
           checkPhase = ''
             runHook preCheck
 
@@ -124,7 +124,7 @@
         test-local = {
           type = "app";
           program = toString (pkgs.writeShellScript "test-local-app" ''
-            cd ${self'.packages.letta-rs.src}
+            cd ${self'.packages.letta.src}
             ${testLocalServer}
           '');
         };
@@ -132,7 +132,7 @@
         test-cloud = {
           type = "app";
           program = toString (pkgs.writeShellScript "test-cloud-app" ''
-            cd ${self'.packages.letta-rs.src}
+            cd ${self'.packages.letta.src}
 
             if [ -z "''${LETTA_API_KEY:-}" ]; then
               echo "❌ LETTA_API_KEY environment variable is required"
@@ -147,7 +147,7 @@
         test-all = {
           type = "app";
           program = toString (pkgs.writeShellScript "test-all-app" ''
-            cd ${self'.packages.letta-rs.src}
+            cd ${self'.packages.letta.src}
 
             echo "🧪 Running all tests..."
 

--- a/src/api/agents.rs
+++ b/src/api/agents.rs
@@ -258,8 +258,8 @@ impl<'a> AgentApi<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use letta_rs::{LettaClient, ClientConfig};
-    /// # use letta_rs::types::PaginationParams;
+    /// # use letta::{LettaClient, ClientConfig};
+    /// # use letta::types::PaginationParams;
     /// # use futures::StreamExt;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = LettaClient::new(ClientConfig::new("http://localhost:8283")?)?;

--- a/src/api/identities.rs
+++ b/src/api/identities.rs
@@ -206,8 +206,8 @@ impl<'a> IdentitiesApi<'a> {
     /// # Example
     ///
     /// ```no_run
-    /// # use letta_rs::client::{ClientConfig, LettaClient};
-    /// # use letta_rs::{types::PaginationParams, pagination::PaginationExt};
+    /// # use letta::client::{ClientConfig, LettaClient};
+    /// # use letta::{types::PaginationParams, pagination::PaginationExt};
     /// # use futures::StreamExt;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/api/memory.rs
+++ b/src/api/memory.rs
@@ -175,8 +175,8 @@ impl<'a> MemoryApi<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use letta_rs::{LettaClient, ClientConfig};
-    /// # use letta_rs::types::{PaginationParams, LettaId};
+    /// # use letta::{LettaClient, ClientConfig};
+    /// # use letta::types::{PaginationParams, LettaId};
     /// # use futures::StreamExt;
     /// # use std::str::FromStr;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/api/messages.rs
+++ b/src/api/messages.rs
@@ -133,14 +133,14 @@ impl<'a> MessageApi<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use letta_rs::types::{MessageCreate, MessageRole, CreateMessagesRequest, MessageCreateContent};
-    /// # use letta_rs::api::messages::StreamingEvent;
-    /// # use letta_rs::LettaId;
+    /// # use letta::types::{MessageCreate, MessageRole, CreateMessagesRequest, MessageCreateContent};
+    /// # use letta::api::messages::StreamingEvent;
+    /// # use letta::LettaId;
     /// # use std::str::FromStr;
     /// # use futures::StreamExt;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let client = letta_rs::LettaClient::new(
-    /// #     letta_rs::client::ClientConfig::new("http://localhost:8283")?
+    /// # let client = letta::LettaClient::new(
+    /// #     letta::client::ClientConfig::new("http://localhost:8283")?
     /// # )?;
     /// let mut stream = client
     ///     .messages()
@@ -310,8 +310,8 @@ impl<'a> MessageApi<'a> {
     /// # Examples
     ///
     /// ```no_run
-    /// # use letta_rs::{LettaClient, ClientConfig};
-    /// # use letta_rs::types::{PaginationParams, LettaId};
+    /// # use letta::{LettaClient, ClientConfig};
+    /// # use letta::types::{PaginationParams, LettaId};
     /// # use futures::StreamExt;
     /// # use std::str::FromStr;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/api/providers.rs
+++ b/src/api/providers.rs
@@ -133,8 +133,8 @@ impl<'a> ProvidersApi<'a> {
     /// # Example
     ///
     /// ```no_run
-    /// # use letta_rs::client::{ClientConfig, LettaClient};
-    /// # use letta_rs::{types::PaginationParams, pagination::PaginationExt};
+    /// # use letta::client::{ClientConfig, LettaClient};
+    /// # use letta::{types::PaginationParams, pagination::PaginationExt};
     /// # use futures::StreamExt;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/api/sources.rs
+++ b/src/api/sources.rs
@@ -156,9 +156,9 @@ impl<'a> SourceApi<'a> {
     /// # Example
     ///
     /// ```no_run
-    /// # use letta_rs::client::{ClientConfig, LettaClient};
-    /// # use letta_rs::{types::PaginationParams, pagination::PaginationExt};
-    /// # use letta_rs::types::LettaId;
+    /// # use letta::client::{ClientConfig, LettaClient};
+    /// # use letta::{types::PaginationParams, pagination::PaginationExt};
+    /// # use letta::types::LettaId;
     /// # use futures::StreamExt;
     /// # use std::str::FromStr;
     /// # #[tokio::main]
@@ -218,9 +218,9 @@ impl<'a> SourceApi<'a> {
     /// # Example
     ///
     /// ```no_run
-    /// # use letta_rs::client::{ClientConfig, LettaClient};
-    /// # use letta_rs::{types::PaginationParams, pagination::PaginationExt};
-    /// # use letta_rs::types::LettaId;
+    /// # use letta::client::{ClientConfig, LettaClient};
+    /// # use letta::{types::PaginationParams, pagination::PaginationExt};
+    /// # use letta::types::LettaId;
     /// # use futures::StreamExt;
     /// # use std::str::FromStr;
     /// # #[tokio::main]

--- a/src/api/tags.rs
+++ b/src/api/tags.rs
@@ -60,8 +60,8 @@ impl<'a> TagsApi<'a> {
     /// # Example
     ///
     /// ```no_run
-    /// # use letta_rs::client::{ClientConfig, LettaClient};
-    /// # use letta_rs::{types::PaginationParams, pagination::PaginationExt};
+    /// # use letta::client::{ClientConfig, LettaClient};
+    /// # use letta::{types::PaginationParams, pagination::PaginationExt};
     /// # use futures::StreamExt;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/api/tools.rs
+++ b/src/api/tools.rs
@@ -237,7 +237,7 @@ impl<'a> ToolApi<'a> {
     /// # Example
     ///
     /// ```no_run
-    /// # use letta_rs::{LettaClient, RunToolFromSourceRequest, SourceType};
+    /// # use letta::{LettaClient, RunToolFromSourceRequest, SourceType};
     /// # use serde_json::json;
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// # let client = LettaClient::local()?;
@@ -366,8 +366,8 @@ impl<'a> ToolApi<'a> {
     /// # Example
     ///
     /// ```no_run
-    /// # use letta_rs::client::{ClientConfig, LettaClient};
-    /// # use letta_rs::{types::PaginationParams, pagination::PaginationExt};
+    /// # use letta::client::{ClientConfig, LettaClient};
+    /// # use letta::{types::PaginationParams, pagination::PaginationExt};
     /// # use futures::StreamExt;
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -32,7 +32,7 @@ impl AuthConfig {
     /// # Examples
     ///
     /// ```rust
-    /// use letta_rs::auth::AuthConfig;
+    /// use letta::auth::AuthConfig;
     ///
     /// let auth = AuthConfig::bearer("your-api-key-here");
     /// ```
@@ -50,7 +50,7 @@ impl AuthConfig {
     /// # Examples
     ///
     /// ```rust
-    /// use letta_rs::auth::AuthConfig;
+    /// use letta::auth::AuthConfig;
     ///
     /// let auth = AuthConfig::none();
     /// ```
@@ -93,7 +93,7 @@ impl AuthConfig {
     /// # Examples
     ///
     /// ```rust
-    /// use letta_rs::auth::AuthConfig;
+    /// use letta::auth::AuthConfig;
     ///
     /// let auth = AuthConfig::bearer("token");
     /// assert!(auth.is_authenticated());
@@ -171,7 +171,7 @@ impl Default for AuthConfig {
 /// # Examples
 ///
 /// ```rust
-/// use letta_rs::auth::from_env;
+/// use letta::auth::from_env;
 ///
 /// // Assumes LETTA_API_KEY environment variable is set
 /// let auth = from_env().unwrap_or_default();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,9 +1,9 @@
 //! Command-line interface for the Letta client.
 
 use clap::Parser;
-use letta_rs::types::agent::{AgentType, CreateAgentRequest};
-use letta_rs::types::memory::MemoryBlock;
-use letta_rs::{auth::AuthConfig, ClientConfig, LettaClient};
+use letta::types::agent::{AgentType, CreateAgentRequest};
+use letta::types::memory::MemoryBlock;
+use letta::{auth::AuthConfig, ClientConfig, LettaClient};
 
 #[derive(Parser, Debug)]
 #[clap(author = "Orual", version, about = "Letta REST API client")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,7 +2,7 @@
 
 use clap::Parser;
 use letta::types::agent::{AgentType, CreateAgentRequest};
-use letta::types::memory::MemoryBlock;
+use letta::types::memory::Block;
 use letta::{auth::AuthConfig, ClientConfig, LettaClient};
 
 #[derive(Parser, Debug)]
@@ -151,7 +151,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 async fn list_agents(
-    client: &LettaClient,
+    _client: &LettaClient,
     limit: u32,
     tags: Vec<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -162,7 +162,7 @@ async fn list_agents(
 }
 
 async fn create_agent(
-    client: &LettaClient,
+    _client: &LettaClient,
     name: String,
     system: Option<String>,
     agent_type: String,
@@ -199,7 +199,7 @@ async fn create_agent(
 
     // Add default memory blocks
     request = request
-        .memory_block(MemoryBlock {
+        .memory_block(Block {
             id: None,
             label: "human".to_string(),
             value: "The human's name is not yet known.".to_string(),
@@ -216,7 +216,7 @@ async fn create_agent(
             created_at: None,
             updated_at: None,
         })
-        .memory_block(MemoryBlock {
+        .memory_block(Block {
             id: None,
             label: "persona".to_string(),
             value: format!("I am {}, a helpful AI assistant.", name),
@@ -282,9 +282,9 @@ async fn create_agent(
 }
 
 async fn get_agent(
-    client: &LettaClient,
+    _client: &LettaClient,
     id: &str,
-    output: &str,
+    _output: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("Getting agent {}...", id);
     // TODO: Implement when agent API is ready
@@ -293,7 +293,7 @@ async fn get_agent(
 }
 
 async fn delete_agent(
-    client: &LettaClient,
+    _client: &LettaClient,
     id: &str,
     yes: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1140,7 +1140,7 @@ pub trait ErrorContext<T> {
     ///
     /// # Example
     /// ```no_run
-    /// # use letta_rs::error::{LettaResult, ErrorContext};
+    /// # use letta::error::{LettaResult, ErrorContext};
     /// # async fn example() -> LettaResult<()> {
     /// # let path = "test.txt";
     /// # let result: LettaResult<()> = Ok(());
@@ -1154,7 +1154,7 @@ pub trait ErrorContext<T> {
     ///
     /// # Example
     /// ```no_run
-    /// # use letta_rs::error::{LettaResult, ErrorContext};
+    /// # use letta::error::{LettaResult, ErrorContext};
     /// # async fn example() -> LettaResult<()> {
     /// # let result: LettaResult<()> = Ok(());
     /// result.context_resource("agent", "agent-123")?;
@@ -1167,7 +1167,7 @@ pub trait ErrorContext<T> {
     ///
     /// # Example
     /// ```no_run
-    /// # use letta_rs::error::{LettaResult, ErrorContext};
+    /// # use letta::error::{LettaResult, ErrorContext};
     /// # async fn example() -> LettaResult<()> {
     /// # let result: LettaResult<()> = Ok(());
     /// result.context_operation("uploading file")?;
@@ -1180,7 +1180,7 @@ pub trait ErrorContext<T> {
     ///
     /// # Example
     /// ```no_run
-    /// # use letta_rs::error::{LettaResult, ErrorContext};
+    /// # use letta::error::{LettaResult, ErrorContext};
     /// # async fn example() -> LettaResult<()> {
     /// # let result: LettaResult<()> = Ok(());
     /// result.context_msg("while processing batch request")?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! ## Quick Start
 //!
 //! ```rust,no_run
-//! use letta_rs::{LettaClient, LettaEnvironment};
+//! use letta::{LettaClient, LettaEnvironment};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -22,7 +22,7 @@
 //!     // Or use the builder for custom configuration
 //!     // let client = LettaClient::builder()
 //!     //     .environment(LettaEnvironment::Cloud)
-//!     //     .auth(letta_rs::auth::AuthConfig::bearer("your-token"))
+//!     //     .auth(letta::auth::AuthConfig::bearer("your-token"))
 //!     //     .base_url("https://custom.letta.com")  // optional override
 //!     //     .build()?;
 //!
@@ -37,7 +37,7 @@
 //! ## Creating and Interacting with Agents
 //!
 //! ```rust,no_run
-//! use letta_rs::{LettaClient, types::*};
+//! use letta::{LettaClient, types::*};
 //! use futures::StreamExt;
 //!
 //! #[tokio::main]
@@ -108,7 +108,7 @@
 //! ## Memory Management
 //!
 //! ```rust,no_run
-//! use letta_rs::{LettaClient, types::*};
+//! use letta::{LettaClient, types::*};
 //! use std::str::FromStr;
 //! use futures::StreamExt;
 //!
@@ -175,7 +175,7 @@
 //! ## Pagination Support
 //!
 //! ```rust,no_run
-//! use letta_rs::{LettaClient, types::*};
+//! use letta::{LettaClient, types::*};
 //! use futures::StreamExt;
 //! use std::str::FromStr;
 //!

--- a/src/pagination.rs
+++ b/src/pagination.rs
@@ -336,6 +336,7 @@ mod tests {
 
     #[derive(Debug, Clone)]
     struct TestItem {
+        #[allow(dead_code)]
         id: LettaId,
         name: String,
     }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -17,7 +17,7 @@ pub mod agents {
     ///
     /// # Example
     /// ```no_run
-    /// use letta_rs::test_helpers::agents::test_agent;
+    /// use letta::test_helpers::agents::test_agent;
     ///
     /// let request = test_agent("TestBot");
     /// // Creates an agent with name "TestBot" and sensible test defaults

--- a/src/types/agent.rs
+++ b/src/types/agent.rs
@@ -122,7 +122,7 @@ impl LLMConfig {
     ///
     /// # Example
     /// ```
-    /// # use letta_rs::types::agent::LLMConfig;
+    /// # use letta::types::agent::LLMConfig;
     /// let config = LLMConfig::openai("gpt-4");
     /// assert_eq!(config.model, "gpt-4");
     /// ```
@@ -150,7 +150,7 @@ impl LLMConfig {
     ///
     /// # Example
     /// ```
-    /// # use letta_rs::types::agent::LLMConfig;
+    /// # use letta::types::agent::LLMConfig;
     /// let config = LLMConfig::anthropic("claude-3-sonnet-20240229");
     /// assert_eq!(config.model, "claude-3-sonnet-20240229");
     /// ```
@@ -178,7 +178,7 @@ impl LLMConfig {
     ///
     /// # Example
     /// ```
-    /// # use letta_rs::types::agent::LLMConfig;
+    /// # use letta::types::agent::LLMConfig;
     /// let config = LLMConfig::local("llama2", "http://localhost:8080");
     /// assert_eq!(config.model, "llama2");
     /// ```

--- a/src/types/common.rs
+++ b/src/types/common.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 /// # Examples
 ///
 /// ```
-/// use letta_rs::types::LettaId;
+/// use letta::types::LettaId;
 /// use std::str::FromStr;
 ///
 /// // Bare UUID

--- a/src/types/memory.rs
+++ b/src/types/memory.rs
@@ -144,7 +144,7 @@ impl Block {
     ///
     /// # Example
     /// ```
-    /// # use letta_rs::types::memory::Block;
+    /// # use letta::types::memory::Block;
     /// let block = Block::human("The human's name is Alice");
     /// assert_eq!(block.label, "human");
     /// assert_eq!(block.value, "The human's name is Alice");
@@ -173,7 +173,7 @@ impl Block {
     ///
     /// # Example
     /// ```
-    /// # use letta_rs::types::memory::Block;
+    /// # use letta::types::memory::Block;
     /// let block = Block::persona("I am a helpful assistant");
     /// assert_eq!(block.label, "persona");
     /// assert_eq!(block.value, "I am a helpful assistant");
@@ -202,7 +202,7 @@ impl Block {
     ///
     /// # Example
     /// ```
-    /// # use letta_rs::types::memory::Block;
+    /// # use letta::types::memory::Block;
     /// let block = Block::new("system", "System information goes here")
     ///     .with_limit(1000)
     ///     .with_description("System-level information");

--- a/tests/agent_deserialization_test.rs
+++ b/tests/agent_deserialization_test.rs
@@ -1,6 +1,6 @@
 //! Test agent deserialization step by step.
 
-use letta_rs::types::AgentState;
+use letta::types::AgentState;
 
 #[tokio::test]
 async fn test_agent_deserialization() {

--- a/tests/archival_memory_test.rs
+++ b/tests/archival_memory_test.rs
@@ -1,12 +1,12 @@
 //! Integration tests for archival memory API endpoints.
 
-use letta_rs::client::ClientBuilder;
-use letta_rs::error::LettaResult;
-use letta_rs::types::agent::CreateAgentRequest;
-use letta_rs::types::memory::{
+use letta::client::ClientBuilder;
+use letta::error::LettaResult;
+use letta::types::agent::CreateAgentRequest;
+use letta::types::memory::{
     ArchivalMemoryQueryParams, Block, CreateArchivalMemoryRequest, UpdateArchivalMemoryRequest,
 };
-use letta_rs::{LettaClient, LettaId};
+use letta::{LettaClient, LettaId};
 use serial_test::serial;
 
 /// Create a test client for the local server.

--- a/tests/azure_message_test.rs
+++ b/tests/azure_message_test.rs
@@ -1,7 +1,7 @@
 //! Test Azure message creation specifically.
 
-use letta_rs::types::{AgentType, CreateAgentRequest};
-use letta_rs::{ClientConfig, LettaClient};
+use letta::types::{AgentType, CreateAgentRequest};
+use letta::{ClientConfig, LettaClient};
 
 #[tokio::test]
 async fn test_azure_message_creation() {
@@ -30,12 +30,10 @@ async fn test_azure_message_creation() {
     println!("Created agent: {} ({})", agent.name, agent_id);
 
     println!("Testing message creation with Azure agent...");
-    let message_request = letta_rs::types::CreateMessagesRequest {
-        messages: vec![letta_rs::types::MessageCreate {
-            role: letta_rs::types::MessageRole::User,
-            content: letta_rs::types::MessageCreateContent::String(
-                "Hello from Rust SDK!".to_string(),
-            ),
+    let message_request = letta::types::CreateMessagesRequest {
+        messages: vec![letta::types::MessageCreate {
+            role: letta::types::MessageRole::User,
+            content: letta::types::MessageCreateContent::String("Hello from Rust SDK!".to_string()),
             name: None,
             otid: None,
             sender_id: None,
@@ -51,7 +49,7 @@ async fn test_azure_message_creation() {
             println!("✅ Success!");
             println!("Messages: {}", response.messages.len());
             for (i, msg) in response.messages.iter().enumerate() {
-                use letta_rs::types::LettaMessageUnion;
+                use letta::types::LettaMessageUnion;
                 let type_str = match msg {
                     LettaMessageUnion::SystemMessage(_) => "System",
                     LettaMessageUnion::UserMessage(_) => "User",

--- a/tests/batch_api_test.rs
+++ b/tests/batch_api_test.rs
@@ -1,8 +1,8 @@
 //! Integration tests for the Batch API.
 
-use letta_rs::client::{ClientConfig, LettaClient};
-use letta_rs::error::LettaResult;
-use letta_rs::types::*;
+use letta::client::{ClientConfig, LettaClient};
+use letta::error::LettaResult;
+use letta::types::*;
 use std::str::FromStr;
 
 /// Get a test client for the local server.
@@ -117,7 +117,7 @@ async fn test_cancel_batch() -> LettaResult<()> {
 
     // Expect this to fail with 404
     match result {
-        Err(letta_rs::error::LettaError::NotFound { resource_type, .. }) => {
+        Err(letta::error::LettaError::NotFound { resource_type, .. }) => {
             println!("Expected NotFound error for non-existent batch");
             println!("Resource type: {}", resource_type);
             // The server returns "Run" for this endpoint
@@ -130,7 +130,7 @@ async fn test_cancel_batch() -> LettaResult<()> {
             );
             Ok(())
         }
-        Err(letta_rs::error::LettaError::Api { status: 404, .. }) => {
+        Err(letta::error::LettaError::Api { status: 404, .. }) => {
             println!("Got 404 API error for non-existent batch");
             Ok(())
         }

--- a/tests/blocks_api_test.rs
+++ b/tests/blocks_api_test.rs
@@ -1,9 +1,9 @@
 //! Integration tests for blocks API endpoints.
 
-use letta_rs::client::ClientBuilder;
-use letta_rs::error::LettaResult;
-use letta_rs::types::{Block, CreateBlockRequest, ListBlocksParams, Metadata, UpdateBlockRequest};
-use letta_rs::{LettaClient, LettaId};
+use letta::client::ClientBuilder;
+use letta::error::LettaResult;
+use letta::types::{Block, CreateBlockRequest, ListBlocksParams, Metadata, UpdateBlockRequest};
+use letta::{LettaClient, LettaId};
 use serial_test::serial;
 use std::collections::HashMap;
 use std::str::FromStr;

--- a/tests/cloud_api_test.rs
+++ b/tests/cloud_api_test.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the cloud Letta API endpoints.
 
-use letta_rs::auth::AuthConfig;
-use letta_rs::{types::AgentsSearchRequest, ClientConfig, LettaClient, LettaId};
+use letta::auth::AuthConfig;
+use letta::{types::AgentsSearchRequest, ClientConfig, LettaClient, LettaId};
 use std::env;
 use std::str::FromStr;
 
@@ -125,9 +125,9 @@ async fn test_cloud_message_operations() {
 
     // Create a test agent for cloud message operations
     println!("Creating test agent for cloud message operations...");
-    let create_request = letta_rs::types::CreateAgentRequest::builder()
+    let create_request = letta::types::CreateAgentRequest::builder()
         .name("Cloud Message Test Agent")
-        .agent_type(letta_rs::types::AgentType::MemGPT)
+        .agent_type(letta::types::AgentType::MemGPT)
         .model("openai/gpt-4o-mini")
         .embedding("openai/text-embedding-3-small")
         .build();
@@ -151,10 +151,10 @@ async fn test_cloud_message_operations() {
 
     // Test 2: Send a message
     println!("\nTesting message creation...");
-    let message_request = letta_rs::types::CreateMessagesRequest {
-        messages: vec![letta_rs::types::MessageCreate {
-            role: letta_rs::types::MessageRole::User,
-            content: letta_rs::types::MessageCreateContent::String(
+    let message_request = letta::types::CreateMessagesRequest {
+        messages: vec![letta::types::MessageCreate {
+            role: letta::types::MessageRole::User,
+            content: letta::types::MessageCreateContent::String(
                 "Hello from Rust SDK cloud test!".to_string(),
             ),
             name: None,
@@ -182,7 +182,7 @@ async fn test_cloud_message_operations() {
 
             // Print response messages
             for (i, message) in response.messages.iter().enumerate() {
-                use letta_rs::types::LettaMessageUnion;
+                use letta::types::LettaMessageUnion;
                 let type_str = match message {
                     LettaMessageUnion::SystemMessage(_) => "System",
                     LettaMessageUnion::UserMessage(_) => "User",

--- a/tests/cloud_sources_test.rs
+++ b/tests/cloud_sources_test.rs
@@ -1,13 +1,13 @@
 //! Cloud API integration tests for sources endpoints.
 
 use bytes::Bytes;
-use letta_rs::auth::AuthConfig;
-use letta_rs::client::ClientBuilder;
-use letta_rs::error::LettaResult;
-use letta_rs::types::agent::{AgentState, CreateAgentRequest};
-use letta_rs::types::memory::Block;
-use letta_rs::types::source::{CreateSourceRequest, Source, UpdateSourceRequest};
-use letta_rs::LettaClient;
+use letta::auth::AuthConfig;
+use letta::client::ClientBuilder;
+use letta::error::LettaResult;
+use letta::types::agent::{AgentState, CreateAgentRequest};
+use letta::types::memory::Block;
+use letta::types::source::{CreateSourceRequest, Source, UpdateSourceRequest};
+use letta::LettaClient;
 use serial_test::serial;
 use std::time::Duration;
 use tokio::time::sleep;
@@ -161,7 +161,7 @@ async fn test_cloud_file_upload_behavior() -> LettaResult<()> {
         )
         .await?;
 
-    use letta_rs::types::source::FileUploadResponse;
+    use letta::types::source::FileUploadResponse;
 
     match upload_result {
         FileUploadResponse::Job(job) => {
@@ -308,7 +308,7 @@ async fn test_cloud_passages_behavior() -> LettaResult<()> {
         )
         .await?;
 
-    use letta_rs::types::source::FileUploadResponse;
+    use letta::types::source::FileUploadResponse;
 
     let actual_filename = match upload_job {
         FileUploadResponse::Job(job) => job.metadata.as_ref().unwrap().filename.clone(),

--- a/tests/composio_integration_test.rs
+++ b/tests/composio_integration_test.rs
@@ -1,7 +1,7 @@
 //! Integration tests for Composio endpoints.
 
-use letta_rs::error::LettaResult;
-use letta_rs::LettaClient;
+use letta::error::LettaResult;
+use letta::LettaClient;
 use serial_test::serial;
 
 fn setup_test_client() -> LettaResult<LettaClient> {

--- a/tests/core_memory_test.rs
+++ b/tests/core_memory_test.rs
@@ -1,10 +1,10 @@
 //! Integration tests for core memory API endpoints.
 
-use letta_rs::client::ClientBuilder;
-use letta_rs::error::LettaResult;
-use letta_rs::types::agent::CreateAgentRequest;
-use letta_rs::types::memory::{Block, UpdateMemoryBlockRequest};
-use letta_rs::{LettaClient, LettaId};
+use letta::client::ClientBuilder;
+use letta::error::LettaResult;
+use letta::types::agent::CreateAgentRequest;
+use letta::types::memory::{Block, UpdateMemoryBlockRequest};
+use letta::{LettaClient, LettaId};
 use serial_test::serial;
 
 /// Create a test client for the local server.

--- a/tests/error_handling_test.rs
+++ b/tests/error_handling_test.rs
@@ -1,7 +1,7 @@
 //! Test that error handling properly causes test failures.
 
-use letta_rs::client::{ClientConfig, LettaClient};
-use letta_rs::types::*;
+use letta::client::{ClientConfig, LettaClient};
+use letta::types::*;
 
 #[tokio::test]
 #[should_panic(expected = "Failed to create agent")]

--- a/tests/groups_api_test.rs
+++ b/tests/groups_api_test.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the Groups API.
 
-use letta_rs::client::{ClientConfig, LettaClient};
-use letta_rs::types::*;
+use letta::client::{ClientConfig, LettaClient};
+use letta::types::*;
 
 /// Get a test client for the local server.
 fn get_test_client() -> LettaClient {

--- a/tests/health_api_test.rs
+++ b/tests/health_api_test.rs
@@ -1,8 +1,8 @@
 //! Integration tests for health API endpoint.
 
-use letta_rs::client::ClientBuilder;
-use letta_rs::error::LettaResult;
-use letta_rs::LettaClient;
+use letta::client::ClientBuilder;
+use letta::error::LettaResult;
+use letta::LettaClient;
 
 /// Create a test client for the local server.
 fn create_test_client() -> LettaResult<LettaClient> {

--- a/tests/identities_api_test.rs
+++ b/tests/identities_api_test.rs
@@ -1,8 +1,8 @@
 //! Integration tests for the Identities API.
 
-use letta_rs::client::{ClientConfig, LettaClient};
-use letta_rs::error::LettaResult;
-use letta_rs::types::*;
+use letta::client::{ClientConfig, LettaClient};
+use letta::error::LettaResult;
+use letta::types::*;
 
 /// Get a test client for the local server.
 fn get_test_client() -> LettaResult<LettaClient> {

--- a/tests/jobs_api_test.rs
+++ b/tests/jobs_api_test.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the Jobs & Steps API.
 
-use letta_rs::client::{ClientConfig, LettaClient};
-use letta_rs::types::*;
+use letta::client::{ClientConfig, LettaClient};
+use letta::types::*;
 
 /// Get a test client for the local server.
 fn get_test_client() -> LettaClient {

--- a/tests/local_server_test.rs
+++ b/tests/local_server_test.rs
@@ -1,10 +1,10 @@
 //! Integration tests for the local Letta server.
 
-use letta_rs::types::{
+use letta::types::{
     AgentType, AgentsSearchRequest, CreateAgentRequest, ImportAgentRequest, ListAgentsParams,
     ToolRule,
 };
-use letta_rs::{ClientConfig, LettaClient, LettaId};
+use letta::{ClientConfig, LettaClient, LettaId};
 use std::path::Path;
 use std::str::FromStr;
 

--- a/tests/mcp_integration_test.rs
+++ b/tests/mcp_integration_test.rs
@@ -1,6 +1,6 @@
 //! Integration tests for MCP (Model Context Protocol) server endpoints.
 
-use letta_rs::{
+use letta::{
     client::LettaClient, McpServerConfig, McpServerType, SseServerConfig, StdioServerConfig,
     StreamableHttpServerConfig, TestMcpServerRequest, UpdateMcpServerRequest, UpdateSseMcpServer,
 };

--- a/tests/message_api_test.rs
+++ b/tests/message_api_test.rs
@@ -1,9 +1,9 @@
 //! Integration tests for the message API.
 
+use letta::types::memory::Block;
 use letta::types::{
-    AgentType, Block, CreateAgentRequest, CreateMessagesRequest, MessageCreate,
-    MessageCreateContent, MessageRole, UpdateMessageRequest, UpdateUserMessage,
-    UpdateUserMessageContent,
+    AgentType, CreateAgentRequest, CreateMessagesRequest, MessageCreate, MessageCreateContent,
+    MessageRole, UpdateMessageRequest, UpdateUserMessage, UpdateUserMessageContent,
 };
 use letta::{ClientConfig, LettaClient};
 use serial_test::serial;
@@ -21,6 +21,8 @@ async fn test_local_server_message_operations() {
         .agent_type(AgentType::MemGPT)
         .model("letta/letta-free")
         .embedding("letta/letta-free")
+        .memory_block(Block::human("The human's name is User"))
+        .memory_block(Block::persona("I am a helpful assistant"))
         .build();
 
     let agent = client.agents().create(create_request).await.unwrap();
@@ -170,6 +172,8 @@ async fn test_update_user_message() {
         .agent_type(AgentType::MemGPT)
         .model("letta/letta-free")
         .embedding("letta/letta-free")
+        .memory_block(Block::human("The human's name is User"))
+        .memory_block(Block::persona("I am a helpful assistant"))
         .build();
 
     let agent = client.agents().create(create_request).await.unwrap();
@@ -252,6 +256,8 @@ async fn test_create_async_message() {
         .agent_type(AgentType::MemGPT)
         .model("letta/letta-free")
         .embedding("letta/letta-free")
+        .memory_block(Block::human("The human's name is User"))
+        .memory_block(Block::persona("I am a helpful assistant"))
         .build();
 
     let agent = client.agents().create(create_request).await.unwrap();
@@ -317,6 +323,8 @@ async fn test_message_pagination() {
         .agent_type(AgentType::MemGPT)
         .model("letta/letta-free")
         .embedding("letta/letta-free")
+        .memory_block(Block::human("The human's name is User"))
+        .memory_block(Block::persona("I am a helpful assistant"))
         .build();
 
     let agent = client.agents().create(create_request).await.unwrap();

--- a/tests/message_api_test.rs
+++ b/tests/message_api_test.rs
@@ -1,11 +1,11 @@
 //! Integration tests for the message API.
 
-use letta_rs::types::{
+use letta::types::{
     AgentType, Block, CreateAgentRequest, CreateMessagesRequest, MessageCreate,
     MessageCreateContent, MessageRole, UpdateMessageRequest, UpdateUserMessage,
     UpdateUserMessageContent,
 };
-use letta_rs::{ClientConfig, LettaClient};
+use letta::{ClientConfig, LettaClient};
 use serial_test::serial;
 
 #[tokio::test]
@@ -67,16 +67,16 @@ async fn test_local_server_message_operations() {
     // Print response messages
     for (i, message) in response.messages.iter().enumerate() {
         match message {
-            letta_rs::types::LettaMessageUnion::UserMessage(msg) => {
+            letta::types::LettaMessageUnion::UserMessage(msg) => {
                 println!("   Message {}: [User] {}", i + 1, msg.content);
             }
-            letta_rs::types::LettaMessageUnion::AssistantMessage(msg) => {
+            letta::types::LettaMessageUnion::AssistantMessage(msg) => {
                 println!("   Message {}: [Assistant] {}", i + 1, msg.content);
             }
-            letta_rs::types::LettaMessageUnion::SystemMessage(msg) => {
+            letta::types::LettaMessageUnion::SystemMessage(msg) => {
                 println!("   Message {}: [System] {}", i + 1, msg.content);
             }
-            letta_rs::types::LettaMessageUnion::ReasoningMessage(msg) => {
+            letta::types::LettaMessageUnion::ReasoningMessage(msg) => {
                 println!("   Message {}: [Reasoning] {}", i + 1, msg.reasoning);
             }
             _ => {
@@ -199,7 +199,7 @@ async fn test_update_user_message() {
     let user_message_id = messages
         .iter()
         .find_map(|msg| match msg {
-            letta_rs::types::LettaMessageUnion::UserMessage(user_msg)
+            letta::types::LettaMessageUnion::UserMessage(user_msg)
                 if user_msg.content == "Original message content" =>
             {
                 Some(user_msg.id.clone())
@@ -221,7 +221,7 @@ async fn test_update_user_message() {
 
     // Verify the update
     match updated_message {
-        letta_rs::types::LettaMessageUnion::UserMessage(user_msg) => {
+        letta::types::LettaMessageUnion::UserMessage(user_msg) => {
             assert_eq!(user_msg.content, "Updated message content");
             println!("✅ Message update successful!");
         }
@@ -281,9 +281,9 @@ async fn test_create_async_message() {
     // Check initial status
     if let Some(status) = run.status {
         match status {
-            letta_rs::types::JobStatus::Created
-            | letta_rs::types::JobStatus::Running
-            | letta_rs::types::JobStatus::Pending => {
+            letta::types::JobStatus::Created
+            | letta::types::JobStatus::Running
+            | letta::types::JobStatus::Pending => {
                 println!("   Run status: {:?}", status);
             }
             _ => panic!("Unexpected initial status: {:?}", status),
@@ -304,7 +304,7 @@ async fn test_create_async_message() {
 #[serial]
 async fn test_message_pagination() {
     use futures::StreamExt;
-    use letta_rs::types::PaginationParams;
+    use letta::types::PaginationParams;
 
     // Create client for local server
     let config = ClientConfig::new("http://localhost:8283").unwrap();

--- a/tests/message_streaming_test.rs
+++ b/tests/message_streaming_test.rs
@@ -1,14 +1,14 @@
 //! Integration tests for message streaming with SSE.
 
 use futures::StreamExt;
-use letta_rs::client::ClientBuilder;
-use letta_rs::error::LettaResult;
-use letta_rs::types::agent::{AgentState, AgentType, CreateAgentRequest};
-use letta_rs::types::memory::Block;
-use letta_rs::types::message::{
+use letta::client::ClientBuilder;
+use letta::error::LettaResult;
+use letta::types::agent::{AgentState, AgentType, CreateAgentRequest};
+use letta::types::memory::Block;
+use letta::types::message::{
     CreateMessagesRequest, MessageCreate, MessageCreateContent, MessageRole,
 };
-use letta_rs::{LettaClient, LettaId, StreamingEvent};
+use letta::{LettaClient, LettaId, StreamingEvent};
 use serial_test::serial;
 use std::str::FromStr;
 use std::time::Duration;
@@ -108,7 +108,7 @@ async fn test_message_streaming_basic() -> LettaResult<()> {
                 }
             }
         }
-        Ok::<(), letta_rs::LettaError>(())
+        Ok::<(), letta::LettaError>(())
     })
     .await;
 
@@ -186,7 +186,7 @@ async fn test_message_streaming_with_tokens() -> LettaResult<()> {
                 }
             }
         }
-        Ok::<(), letta_rs::LettaError>(())
+        Ok::<(), letta::LettaError>(())
     })
     .await;
 
@@ -241,7 +241,7 @@ async fn test_message_streaming_error_handling() -> LettaResult<()> {
 #[tokio::test]
 #[serial]
 async fn test_message_streaming_multimodal() -> LettaResult<()> {
-    use letta_rs::types::message::{ContentPart, ImageContent, ImageUrl, TextContent};
+    use letta::types::message::{ContentPart, ImageContent, ImageUrl, TextContent};
 
     let client = create_test_client()?;
 
@@ -304,7 +304,7 @@ async fn test_message_streaming_multimodal() -> LettaResult<()> {
                         }
                     }
                 }
-                Ok::<(), letta_rs::LettaError>(())
+                Ok::<(), letta::LettaError>(())
             })
             .await;
 

--- a/tests/models_api_test.rs
+++ b/tests/models_api_test.rs
@@ -1,8 +1,8 @@
 //! Integration tests for the Models API.
 
-use letta_rs::client::{ClientConfig, LettaClient};
-use letta_rs::error::LettaResult;
-use letta_rs::types::*;
+use letta::client::{ClientConfig, LettaClient};
+use letta::error::LettaResult;
+use letta::types::*;
 
 /// Get a test client for the local server.
 fn get_test_client() -> LettaResult<LettaClient> {

--- a/tests/pagination_test.rs
+++ b/tests/pagination_test.rs
@@ -1,9 +1,9 @@
 //! Integration tests for pagination functionality.
 
 use futures::StreamExt;
-use letta_rs::client::{ClientConfig, LettaClient};
-use letta_rs::error::LettaResult;
-use letta_rs::types::*;
+use letta::client::{ClientConfig, LettaClient};
+use letta::error::LettaResult;
+use letta::types::*;
 use serial_test::serial;
 
 #[tokio::test]

--- a/tests/projects_api_test.rs
+++ b/tests/projects_api_test.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the Projects API (Cloud only).
 
-use letta_rs::client::LettaClient;
-use letta_rs::types::*;
+use letta::client::LettaClient;
+use letta::types::*;
 use std::env;
 
 /// Get a test client for Letta Cloud.

--- a/tests/projects_api_test.rs
+++ b/tests/projects_api_test.rs
@@ -1,7 +1,6 @@
 //! Integration tests for the Projects API (Cloud only).
 
 use letta::client::LettaClient;
-use letta::types::*;
 use std::env;
 
 /// Get a test client for Letta Cloud.

--- a/tests/providers_api_test.rs
+++ b/tests/providers_api_test.rs
@@ -1,8 +1,8 @@
 //! Integration tests for the Providers API.
 
-use letta_rs::client::{ClientConfig, LettaClient};
-use letta_rs::error::LettaResult;
-use letta_rs::types::*;
+use letta::client::{ClientConfig, LettaClient};
+use letta::error::LettaResult;
+use letta::types::*;
 
 /// Get a test client for the local server.
 fn get_test_client() -> LettaResult<LettaClient> {

--- a/tests/retry_test.rs
+++ b/tests/retry_test.rs
@@ -1,8 +1,8 @@
 //! Integration tests for retry logic.
 
-use letta_rs::client::ClientBuilder;
-use letta_rs::error::LettaError;
-use letta_rs::retry::RetryConfig;
+use letta::client::ClientBuilder;
+use letta::error::LettaError;
+use letta::retry::RetryConfig;
 use std::time::Duration;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};

--- a/tests/runs_api_test.rs
+++ b/tests/runs_api_test.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the Runs API.
 
-use letta_rs::client::{ClientConfig, LettaClient};
-use letta_rs::types::*;
+use letta::client::{ClientConfig, LettaClient};
+use letta::types::*;
 use std::str::FromStr;
 
 /// Get a test client for the local server.

--- a/tests/runs_api_test.rs
+++ b/tests/runs_api_test.rs
@@ -2,7 +2,6 @@
 
 use letta::client::{ClientConfig, LettaClient};
 use letta::types::*;
-use std::str::FromStr;
 
 /// Get a test client for the local server.
 fn get_test_client() -> LettaClient {

--- a/tests/sources_api_test.rs
+++ b/tests/sources_api_test.rs
@@ -1,16 +1,16 @@
 //! Integration tests for sources API endpoints.
 
 use bytes::Bytes;
-use letta_rs::client::ClientBuilder;
-use letta_rs::error::LettaResult;
-use letta_rs::types::agent::{AgentState, CreateAgentRequest};
-use letta_rs::types::common::Metadata;
-use letta_rs::types::memory::Block;
-use letta_rs::types::source::{
+use letta::client::ClientBuilder;
+use letta::error::LettaResult;
+use letta::types::agent::{AgentState, CreateAgentRequest};
+use letta::types::common::Metadata;
+use letta::types::memory::Block;
+use letta::types::source::{
     CreateSourceRequest, FileProcessingStatus, FileUploadResponse, GetFileParams, ListFilesParams,
     ListPassagesParams, Source, UpdateSourceRequest,
 };
-use letta_rs::{LettaClient, LettaId};
+use letta::{LettaClient, LettaId};
 use serial_test::serial;
 use std::collections::HashMap;
 use std::str::FromStr;

--- a/tests/tags_api_test.rs
+++ b/tests/tags_api_test.rs
@@ -1,8 +1,8 @@
 //! Integration tests for the Tags API.
 
-use letta_rs::client::{ClientConfig, LettaClient};
-use letta_rs::error::LettaResult;
-use letta_rs::types::*;
+use letta::client::{ClientConfig, LettaClient};
+use letta::error::LettaResult;
+use letta::types::*;
 
 /// Get a test client for the local server.
 fn get_test_client() -> LettaResult<LettaClient> {
@@ -66,7 +66,7 @@ async fn test_list_tags_with_query() -> LettaResult<()> {
 #[tokio::test]
 async fn test_tags_pagination_stream() -> LettaResult<()> {
     use futures::StreamExt;
-    use letta_rs::types::PaginationParams;
+    use letta::types::PaginationParams;
 
     let client = get_test_client()?;
 

--- a/tests/telemetry_api_test.rs
+++ b/tests/telemetry_api_test.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the Telemetry API.
 
-use letta_rs::client::{ClientConfig, LettaClient};
-use letta_rs::error::LettaResult;
+use letta::client::{ClientConfig, LettaClient};
+use letta::error::LettaResult;
 
 /// Get a test client for the local server.
 fn get_test_client() -> LettaResult<LettaClient> {
@@ -24,14 +24,14 @@ async fn test_retrieve_provider_trace() -> LettaResult<()> {
 
     // We expect this to fail with a 404 since the step doesn't exist
     match result {
-        Err(letta_rs::error::LettaError::NotFound { resource_type, id }) => {
+        Err(letta::error::LettaError::NotFound { resource_type, id }) => {
             println!("Expected NotFound error for non-existent step");
             println!("Resource type: {}, ID: {}", resource_type, id);
             // The error extraction identifies this as "ProviderTrace"
             assert_eq!(resource_type, "ProviderTrace");
             Ok(())
         }
-        Err(letta_rs::error::LettaError::Api { status: 404, .. }) => {
+        Err(letta::error::LettaError::Api { status: 404, .. }) => {
             println!("Got 404 API error (alternative match)");
             Ok(())
         }

--- a/tests/templates_api_test.rs
+++ b/tests/templates_api_test.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the Templates API (Cloud only).
 
-use letta_rs::client::LettaClient;
-use letta_rs::types::*;
+use letta::client::LettaClient;
+use letta::types::*;
 use std::env;
 
 /// Get a test client for Letta Cloud.

--- a/tests/tools_api_test.rs
+++ b/tests/tools_api_test.rs
@@ -1,13 +1,11 @@
 //! Integration tests for tools API endpoints.
 
-use letta_rs::client::ClientBuilder;
-use letta_rs::error::LettaResult;
-use letta_rs::types::agent::CreateAgentRequest;
-use letta_rs::types::memory::Block;
-use letta_rs::types::tool::{
-    CreateToolRequest, ListToolsParams, SourceType, Tool, UpdateToolRequest,
-};
-use letta_rs::{LettaClient, LettaId};
+use letta::client::ClientBuilder;
+use letta::error::LettaResult;
+use letta::types::agent::CreateAgentRequest;
+use letta::types::memory::Block;
+use letta::types::tool::{CreateToolRequest, ListToolsParams, SourceType, Tool, UpdateToolRequest};
+use letta::{LettaClient, LettaId};
 use serial_test::serial;
 
 /// Create a test client for the local server.
@@ -358,7 +356,7 @@ async fn test_run_tool_from_source() -> LettaResult<()> {
     let client = create_test_client()?;
 
     // Create a simple add function
-    let request = letta_rs::RunToolFromSourceRequest {
+    let request = letta::RunToolFromSourceRequest {
         source_code: r#"
 def add_numbers(a: float, b: float) -> float:
     """Add two numbers together.
@@ -415,7 +413,7 @@ def add_numbers(a: float, b: float) -> float:
     // Run the tool from source
     let result = client.tools().run_from_source(request).await?;
 
-    assert_eq!(result.status, letta_rs::ToolExecutionStatus::Success);
+    assert_eq!(result.status, letta::ToolExecutionStatus::Success);
     assert_eq!(result.tool_return, "8.0");
 
     Ok(())

--- a/tests/voice_api_test.rs
+++ b/tests/voice_api_test.rs
@@ -1,8 +1,8 @@
 //! Integration tests for the Voice API (beta).
 
-use letta_rs::client::{ClientConfig, LettaClient};
-use letta_rs::error::LettaResult;
-use letta_rs::types::*;
+use letta::client::{ClientConfig, LettaClient};
+use letta::error::LettaResult;
+use letta::types::*;
 use serde_json::json;
 use std::str::FromStr;
 


### PR DESCRIPTION
## Summary
- Renamed the crate from `letta-rs` to `letta` to align with other official client libraries
- Updated all internal imports from `letta_rs` to `letta`
- Updated documentation and Nix configuration
- Added compatibility metadata to track tested server versions

## Changes
- Updated `Cargo.toml` package name
- Replaced all `letta_rs` imports in library and tests
- Updated CLI to use new `Block` type (was `MemoryBlock`)
- Added `package.metadata.letta-server-version` to track compatibility
- Added compatibility table to README
- Updated Nix flake configuration
- Fixed test failures by adding memory blocks to agent creation
- Bumped version to 0.1.2

## Testing
- ✅ All unit tests pass
- ✅ All integration tests pass with local Letta server
- ✅ CLI builds and runs correctly

## Breaking Changes
- Users will need to update their imports from `letta_rs` to `letta`
- The crate name in `Cargo.toml` dependencies changes from `letta-rs` to `letta`

🤖 Generated with [Claude Code](https://claude.ai/code)